### PR TITLE
OpenBSD

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -3,24 +3,24 @@
 #    pkg_add -r gmake
 # and then run as gmake rather than make.
 
-ifeq (,$(OS))
-    OS:=$(shell uname)
-    ifeq (Darwin,$(OS))
-        OS:=osx
-    else
-        ifeq (Linux,$(OS))
-            OS:=linux
-        else
-            ifeq (FreeBSD,$(OS))
-                OS:=freebsd
-            else
-				ifeq (OpenBSD,$(OS))
-					OS:=openbsd
-				else
-					$(error Unrecognized or unsupported OS for uname: $(OS))
-				endif
-            endif
-        endif
+ifeq ($(OS),)
+    uname_S:=$(shell uname -s)
+
+    ifeq ($(uname_S),Darwin)
+         OS:=osx
+    endif
+    ifeq ($(uname_S),Linux)
+        OS:=linux
+    endif
+    ifeq ($(uname_S),FreeBSD)
+        OS:=freebsd
+    endif
+    ifeq ($(uname_S),OpenBSD)
+        OS:=openbsd
+    endif
+
+    ifeq ($(OS),)
+        $(error Unrecognized or unsupported OS for uname: $(uname_S))
     endif
 endif
 

--- a/posix.mak
+++ b/posix.mak
@@ -31,10 +31,8 @@ IMPDIR=import
 
 MODEL=32
 
-#XXX fix -O -release: DFLAGS=-m$(MODEL) -O -release -inline -w -Isrc -Iimport -property
-#XXX fix -O -release: UDFLAGS=-m$(MODEL) -O -release -w -Isrc -Iimport -property
-DFLAGS=-m$(MODEL) -release -inline -w -Isrc -Iimport -property
-UDFLAGS=-m$(MODEL) -release -w -Isrc -Iimport -property
+DFLAGS=-m$(MODEL) -O -release -inline -w -Isrc -Iimport -property
+UDFLAGS=-m$(MODEL) -O -release -w -Isrc -Iimport -property
 DDOCFLAGS=-m$(MODEL) -c -w -o- -Isrc -Iimport
 
 CFLAGS=-m$(MODEL) -O

--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -89,8 +89,8 @@ else version ( OpenBSD )
     struct fenv_t
     {
         struct ___x87 {
-            ushort __control;
-            ushort __status;
+            uint __control;
+            uint __status;
             uint __tag;
             uint[4] __other;
         }

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -253,7 +253,7 @@ class Semaphore
 
                 timespec tin = void;
                 tin.tv_sec = 0;
-                tin.tv_nsec = 1;
+                tin.tv_nsec = 100;
                 nanosleep( &tin, null );
 
                 timespec t2 = void;

--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -447,8 +447,7 @@ else version( OpenBSD )
     enum AI_EXT             = 0x8;
     enum AI_NUMERICSERV     = 0x10;
     enum AI_FQDN            = 0x20;
-
-    @property int AI_MASK() { return AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST | AI_NUMERICSERV | AI_FQDN; }
+    enum AI_MASK = AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST | AI_NUMERICSERV | AI_FQDN;
 
     enum NI_NUMERICHOST     = 0x1;
     enum NI_NUMERICSERV     = 0x2;

--- a/win32.mak
+++ b/win32.mak
@@ -78,6 +78,8 @@ MANIFEST= \
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\sys\event.d \
 	\
+	src\core\sys\openbsd\sys\event.d \
+	\
 	src\core\sys\linux\execinfo.d \
 	\
 	src\core\sys\osx\execinfo.d \
@@ -433,6 +435,8 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\execinfo.d \
 	$(IMPDIR)\core\sys\freebsd\sys\event.d \
 	\
+	$(IMPDIR)\core\sys\openbsd\sys\event.d \
+	\
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	\
 	$(IMPDIR)\core\sys\osx\execinfo.d \
@@ -701,6 +705,9 @@ $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\sys\event.d : src\core\sys\freebsd\sys\event.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\event.d : src\core\sys\openbsd\sys\event.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\execinfo.d : src\core\sys\linux\execinfo.d


### PR DESCRIPTION
Here is what I found during code review of the druntime changes.

Two more things that I haven't fixed.
- The sem_timedwait does a busy wait. Probably we can find a better solution using pthread_cond_timedwait.
- core.sys.posix.signal.sigaction_t has an sa_restorer field.
  I think this is linux only and maybe we should split the definition
  instead of using `version (Posix)`.

Overall it looks pretty good for the size of the changes.
